### PR TITLE
refactor(auto_route): Upgrade and migrate auto_route to v6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+

--- a/lib/src/modules/about/presentation/pages/about_page.dart
+++ b/lib/src/modules/about/presentation/pages/about_page.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -5,6 +6,7 @@ import '../../../../common/extensions/build_context_x.dart';
 import '../../application/blocs/about/about_bloc.dart';
 import '../widgets/about_body.dart';
 
+@RoutePage()
 class AboutPage extends StatelessWidget {
   const AboutPage({Key? key}) : super(key: key);
 

--- a/lib/src/modules/app/app_router.dart
+++ b/lib/src/modules/app/app_router.dart
@@ -12,17 +12,17 @@ import '../supportive/presentation/pages/supportive_page.dart';
 
 part 'app_router.gr.dart';
 
-@MaterialAutoRouter(
-  replaceInRouteName: 'Page,Route',
-  routes: <AutoRoute>[
-    AutoRoute(page: SplashPage, initial: true),
-    AutoRoute(page: HomePage),
-    AutoRoute(page: AuthPage),
-    AutoRoute(page: CounterPage),
-    AutoRoute(page: AboutPage),
-    AutoRoute(page: SettingsPage),
-    AutoRoute(page: SupportivePage),
-  ],
-)
 @singleton
-class AppRouter extends _$AppRouter {}
+@AutoRouterConfig(replaceInRouteName: 'Page,Route')
+class AppRouter extends _$AppRouter {
+  @override
+  List<AutoRoute> get routes => [
+    AutoRoute(page: SplashRoute.page, path: '/'),
+    AutoRoute(page: HomeRoute.page),
+    AutoRoute(page: AuthRoute.page),
+    AutoRoute(page: CounterRoute.page),
+    AutoRoute(page: AboutRoute.page),
+    AutoRoute(page: SettingsRoute.page),
+    AutoRoute(page: SupportiveRoute.page),
+  ];
+}

--- a/lib/src/modules/auth/presentation/pages/auth_page.dart
+++ b/lib/src/modules/auth/presentation/pages/auth_page.dart
@@ -1,8 +1,10 @@
+import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../widgets/auth_body.dart';
 
+@RoutePage()
 class AuthPage extends StatelessWidget {
   const AuthPage({Key? key}) : super(key: key);
 

--- a/lib/src/modules/counter/presentation/pages/counter_page.dart
+++ b/lib/src/modules/counter/presentation/pages/counter_page.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -5,6 +6,7 @@ import '../../application/blocs/counter/counter_bloc.dart';
 import '../../application/cubits/tap/tap_cubit.dart';
 import '../widgets/counter_body.dart';
 
+@RoutePage()
 class CounterPage extends StatelessWidget {
   const CounterPage({Key? key}) : super(key: key);
 

--- a/lib/src/modules/home/presentation/pages/home_page.dart
+++ b/lib/src/modules/home/presentation/pages/home_page.dart
@@ -1,8 +1,10 @@
+import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../widgets/home_body.dart';
 
+@RoutePage()
 class HomePage extends StatelessWidget {
   const HomePage({Key? key}) : super(key: key);
 

--- a/lib/src/modules/settings/presentation/pages/settings_page.dart
+++ b/lib/src/modules/settings/presentation/pages/settings_page.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -5,6 +6,7 @@ import '../../../../common/extensions/build_context_x.dart';
 import '../../../../core/application/cubits/auth/auth_cubit.dart';
 import '../widgets/settings_body.dart';
 
+@RoutePage()
 class SettingsPage extends StatelessWidget {
   const SettingsPage({Key? key}) : super(key: key);
 

--- a/lib/src/modules/splash/presentation/pages/splash_page.dart
+++ b/lib/src/modules/splash/presentation/pages/splash_page.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 
 import '../../../../common/extensions/int_duration.dart';
@@ -5,6 +6,7 @@ import '../../../../common/utils/getit_utils.dart';
 import '../../../../core/application/cubits/auth/auth_cubit.dart';
 import '../../../app/app_router.dart';
 
+@RoutePage()
 class SplashPage extends StatelessWidget {
   SplashPage({Key? key}) : super(key: key) {
     fetchAll();

--- a/lib/src/modules/supportive/presentation/pages/supportive_page.dart
+++ b/lib/src/modules/supportive/presentation/pages/supportive_page.dart
@@ -1,5 +1,7 @@
+import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 
+@RoutePage()
 class SupportivePage extends StatelessWidget {
   const SupportivePage({Key? key, required this.title, required this.content})
       : super(key: key);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   intl: ^0.17.0
   asuka: ^2.0.0
-  auto_route: ^5.0.0
+  auto_route: ^6.0.0+1
   bloc: ^8.0.3
   flutter_bloc: ^8.0.1
   flutter_config_plus: ^1.1.1
@@ -46,7 +46,7 @@ dev_dependencies:
     sdk: flutter
   freezed: ^2.1.0
   json_serializable: ^6.4.0
-  auto_route_generator: ^5.0.0
+  auto_route_generator: ^6.0.0
   flutter_gen_runner: ^5.0.1
   intl_utils: ^2.7.0
   injectable_generator: ^2.1.3


### PR DESCRIPTION
Hi @duc-ios ,

[**Auto Route**](https://pub.dev/packages/auto_route) released v6.0.0+1 and introduced will make less code generated for more flexibility and less generation time.
So the PR following [this migration](https://pub.dev/packages/auto_route#migrating-to-v6) will help us migrate from v5.xx to v6.0.0+1