### PR TITLE
fix: typo in flutter_gen config

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,8 +75,11 @@ flutter_gen:
     rive: false
 
   assets:
-    output:
-      enabled: true
+    enabled: true
+    outputs:
+      # Optional
+      # Set to true if you want this package to be a package dependency
+      # See: https://flutter.dev/docs/development/ui/assets-and-images#from-packages
       package_parameter_enabled: false
       style: dot-delimiter
 


### PR DESCRIPTION
Hi @duc-ios,

I found a typo in our codebase while configuring with flutter_gen.
So I created this pull request to fix it. I referred to this guideline: https://github.com/FlutterGen/flutter_gen/blob/main/packages/core/lib/settings/config_default.dart.