### PR TITLE
fix: updated flutter_svg version to compatible with flutter_gen_runner

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter_bloc: ^8.0.1
   flutter_config_plus: ^1.1.1
   flutter_loggy: ^2.0.1
-  flutter_svg: ^2.0.0+1
+  flutter_svg: 2.0.2
   freezed_annotation: ^2.1.0
   json_annotation: ^4.7.0
   dio: ^5.0.0


### PR DESCRIPTION
This PR does the following things:

- Updated fixed version of flutter_svg to **2.0.2** since the latest version of flutter_gen (5.0.2) is not compatible with that of flutter_svg (2.0.4). [More detail](https://github.com/FlutterGen/flutter_gen/issues/372). 
The issue only occurs when we run `flutter clean` or `pub get` for the first time.

I will update the flutter_svg version later if any latest compatible update from the flutter_gen package in the future.