### PR TITLE
feat: replaced streamming_shared_preferences to rx_shared_preferences

### DIFF
--- a/lib/src/core/application/cubits/auth/auth_cubit.dart
+++ b/lib/src/core/application/cubits/auth/auth_cubit.dart
@@ -3,8 +3,8 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
 
 import '../../../../common/utils/validator.dart';
+import '../../../../modules/auth/domain/entities/user.dart';
 import '../../../../modules/auth/domain/interfaces/auth_repository_interface.dart';
-import '../../../../modules/auth/infrastructure/models/user_model.dart';
 import '../../../domain/errors/auth_error.dart';
 import '../../../infrastructure/datasources/remote/api/services/auth/models/login_request.dart';
 

--- a/lib/src/core/application/cubits/auth/auth_state.dart
+++ b/lib/src/core/application/cubits/auth/auth_state.dart
@@ -4,6 +4,6 @@ part of 'auth_cubit.dart';
 class AuthState with _$AuthState {
   const factory AuthState.loading() = _Loading;
   const factory AuthState.error(AuthError error) = _Error;
-  const factory AuthState.authenticated(UserModel user) = _Authenticated;
+  const factory AuthState.authenticated(User user) = _Authenticated;
   const factory AuthState.unauthenticated() = _Unauthenticated;
 }

--- a/lib/src/core/infrastructure/datasources/local/storage.dart
+++ b/lib/src/core/infrastructure/datasources/local/storage.dart
@@ -37,7 +37,7 @@ class Storage {
 
   static T? _get<T>(String key) => _prefs.get(key).asOrNull<T>();
 
-  /// set value to shared preference by [key[.
+  /// set value to shared preference by [key].
   /// If you want the updated value to be notified for stream subscriptions
   /// created by [RxSharedPreferences], please set [notify] as `true`
   static Future<void> _set<T>(String key, T? val, {bool notify = false}) {

--- a/lib/src/core/infrastructure/datasources/local/storage.dart
+++ b/lib/src/core/infrastructure/datasources/local/storage.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
+import 'package:rx_shared_preferences/rx_shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../../../common/extensions/optional_x.dart';
@@ -19,85 +19,75 @@ class _Keys {
 
 class Storage {
   static late final SharedPreferences _prefs;
-  static late final StreamingSharedPreferences _streamPrefs;
+  static late final RxSharedPreferences _rxPrefs;
 
   static const _storage = FlutterSecureStorage();
 
   static setup() async {
     _prefs = await SharedPreferences.getInstance();
-    _streamPrefs = await StreamingSharedPreferences.instance;
+
+    /// A shared preference wrapper providing [Stream] for listening updates
+    /// from shared preference by key
+    _rxPrefs = RxSharedPreferences(
+      _prefs,
+      // disable logging when running in release mode.
+      kReleaseMode ? null : const RxSharedPreferencesDefaultLogger(),
+    );
   }
 
   static T? _get<T>(String key) => _prefs.get(key).asOrNull<T>();
 
-  static Preference<bool> _streamBool(String key, bool defaultValue) {
-    return _streamPrefs.getBool(key, defaultValue: defaultValue);
-  }
-
-  static Preference<int> _streamInt(String key, int defaultValue) {
-    return _streamPrefs.getInt(key, defaultValue: defaultValue);
-  }
-
-  static Preference<String> _streamString(String key, String defaultValue) {
-    return _streamPrefs.getString(key, defaultValue: defaultValue);
-  }
-
-  static Preference<double> _streamDouble(String key, double defaultValue) {
-    return _streamPrefs.getDouble(key, defaultValue: defaultValue);
-  }
-
-  static Preference<T> _streamObject<T>(String key, T defaultValue,
-      {required PreferenceAdapter<T> adapter}) {
-    return _streamPrefs.getCustomValue(key,
-        defaultValue: defaultValue, adapter: adapter);
-  }
-
-  static Preference<List<String>> _streamStringList(
-      String key, List<String> defaultValue) {
-    return _streamPrefs.getStringList(key, defaultValue: defaultValue);
-  }
-
+  /// set value to shared preference by [key[.
+  /// If you want the updated value to be notified for stream subscriptions
+  /// created by [RxSharedPreferences], please set [notify] as `true`
   static Future<void> _set<T>(String key, T? val, {bool notify = false}) {
     if (val is bool) {
-      return notify ? _streamPrefs.setBool(key, val) : _prefs.setBool(key, val);
+      return notify ? _rxPrefs.setBool(key, val) : _prefs.setBool(key, val);
     }
     if (val is double) {
-      return notify
-          ? _streamPrefs.setDouble(key, val)
-          : _prefs.setDouble(key, val);
+      return notify ? _rxPrefs.setDouble(key, val) : _prefs.setDouble(key, val);
     }
     if (val is int) {
-      return notify ? _streamPrefs.setInt(key, val) : _prefs.setInt(key, val);
+      return notify ? _rxPrefs.setInt(key, val) : _prefs.setInt(key, val);
     }
     if (val is String) {
-      return notify
-          ? _streamPrefs.setString(key, val)
-          : _prefs.setString(key, val);
+      return notify ? _rxPrefs.setString(key, val) : _prefs.setString(key, val);
     }
     if (val is List<String>) {
       return notify
-          ? _streamPrefs.setStringList(key, val)
+          ? _rxPrefs.setStringList(key, val)
           : _prefs.setStringList(key, val);
     }
     throw Exception('Type not supported!');
   }
 
-
   static Future<String?> _getSecure(String key) => _storage.read(key: key);
+
   static Future<void> _setSecure(String key, String? val) =>
       _storage.write(key: key, value: val);
 
   static String? get lang => _get(_Keys.lang);
+
   static Future setLang(String? val) => _set(_Keys.lang, val);
 
   static UserModel? get user {
+    final userString = _get<String>(_Keys.user);
+    return _parseUser(userString);
+  }
+
+  static Stream<UserModel?> get userStream {
+    return _rxPrefs
+        .getStringStream(_Keys.user)
+        .map((event) => _parseUser(event));
+  }
+
+  static UserModel? _parseUser(String? userString) {
     try {
-      final userString = _get<String>(_Keys.user);
       if (userString != null) {
         return UserModel.fromJson(json.decode(userString));
       }
-    } catch (error) {
-      logger.e(error);
+    } catch (e) {
+      logger.e(e);
     }
     return null;
   }
@@ -106,6 +96,7 @@ class Storage {
       _set(_Keys.user, json.encode(val?.toJson()));
 
   static Future<String?> get accessToken => _getSecure(_Keys.accessToken);
+
   static Future setAccessToken(String? val) =>
       _setSecure(_Keys.accessToken, val);
 
@@ -121,5 +112,6 @@ class Storage {
   static Future setDeviceId(String? val) => _set(_Keys.deviceId, val);
 
   static String? get pushToken => _get(_Keys.pushToken);
+
   static Future setPushToken(String? val) => _set(_Keys.pushToken, val);
 }

--- a/lib/src/modules/auth/domain/interfaces/auth_repository_interface.dart
+++ b/lib/src/modules/auth/domain/interfaces/auth_repository_interface.dart
@@ -3,11 +3,12 @@ import 'package:dartz/dartz.dart';
 import '../../../../core/infrastructure/datasources/remote/api/base/api_error.dart';
 import '../../../../core/infrastructure/datasources/remote/api/services/auth/models/login_request.dart';
 import '../../infrastructure/models/user_model.dart';
+import '../entities/user.dart';
 
 abstract class IAuthRepository {
   UserModel? getUser();
-  Future setUser(UserModel val);
-  Future<Either<ApiError, UserModel>> login(LoginRequest request);
+  Future setUser(User? val);
+  Future<Either<ApiError, User>> login(LoginRequest request);
   Future<String?> getAccessToken();
   Future setAccessToken(String? val);
   Future logout();

--- a/lib/src/modules/auth/domain/interfaces/auth_repository_interface.dart
+++ b/lib/src/modules/auth/domain/interfaces/auth_repository_interface.dart
@@ -2,11 +2,10 @@ import 'package:dartz/dartz.dart';
 
 import '../../../../core/infrastructure/datasources/remote/api/base/api_error.dart';
 import '../../../../core/infrastructure/datasources/remote/api/services/auth/models/login_request.dart';
-import '../../infrastructure/models/user_model.dart';
 import '../entities/user.dart';
 
 abstract class IAuthRepository {
-  UserModel? getUser();
+  User? getUser();
   Future setUser(User? val);
   Future<Either<ApiError, User>> login(LoginRequest request);
   Future<String?> getAccessToken();

--- a/lib/src/modules/auth/infrastructure/repositories/auth_repository.dart
+++ b/lib/src/modules/auth/infrastructure/repositories/auth_repository.dart
@@ -10,6 +10,7 @@ import '../../../../core/infrastructure/datasources/remote/api/base/api_response
 import '../../../../core/infrastructure/datasources/remote/api/services/auth/auth_path.dart';
 import '../../../../core/infrastructure/datasources/remote/api/services/auth/models/login_request.dart';
 import '../../../../core/infrastructure/datasources/remote/api/services/auth/models/login_response.dart';
+import '../../domain/entities/user.dart';
 import '../../domain/interfaces/auth_repository_interface.dart';
 import '../models/user_model.dart';
 
@@ -23,7 +24,11 @@ class AuthRepository implements IAuthRepository {
   UserModel? getUser() => Storage.user;
 
   @override
-  Future setUser(UserModel? val) async => Storage.setUser(val);
+  Future setUser(User? val) async {
+    if (val is UserModel?) {
+      return Storage.setUser(val);
+    }
+  }
 
   @override
   Future<String?> getAccessToken() => Storage.accessToken;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,8 @@ dependencies:
   uuid: ^3.0.6
   stack_trace: ^1.10.0
   injectable: ^2.1.0
-  streaming_shared_preferences: ^2.0.0
+  rx_shared_preferences: ^3.0.0
+  collection: ^1.17.0
 
 dev_dependencies:
   flutter_lints: ^2.0.0


### PR DESCRIPTION
This PR does the following this:

- Replaced [streamming_shared_preferences](https://pub.dev/packages/streaming_shared_preferences) to [rx_shared_preferences](https://pub.dev/packages/rx_shared_preferences).
Reason: The previous package doesn't support nullable type and isn't maintained actively.

- Removed unused methods

- Replaced UserModel with User to promote abstraction.

- (Non-related) Added [collection](https://pub.dev/packages/collection/install) package for more useful methods on data structures: firstWhereOrNull, mapIndexed...

